### PR TITLE
Updated tools version; Catch exceptions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 group 'geekyappz'
-version '1.0.3'
+version '1.0.4'
 
 apply plugin: 'java'
 
@@ -11,18 +11,22 @@ repositories {
 
 //create a single Jar with all dependencies
 task fatJar(type: Jar) {
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
     manifest {
         attributes 'Implementation-Title': 'Svg2VectorAndroid',
                 'Implementation-Version': version,
                 'Main-Class': 'com.vector.svg2vectorandroid.Runner'
     }
-    baseName = project.name
+    archiveBaseName = project.name
+    from {
+        configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) }
+    }
     exclude 'META-INF/*.RSA', 'META-INF/*.SF','META-INF/*.DSA'
     with jar
 }
 
 dependencies {
     testImplementation group: 'junit', name: 'junit', version: '4.11'
-    implementation 'com.android.tools:sdk-common:27.1.1'
-    implementation 'com.android.tools:common:27.1.1'
+    implementation 'com.android.tools:sdk-common:30.3.0'
+    implementation 'com.android.tools:common:30.3.0'
 }

--- a/src/main/java/com/vector/svg2vectorandroid/SvgFilesProcessor.java
+++ b/src/main/java/com/vector/svg2vectorandroid/SvgFilesProcessor.java
@@ -59,6 +59,8 @@ public class SvgFilesProcessor {
                             return FileVisitResult.SKIP_SUBTREE;
                         }
 
+                        System.out.println("Visiting directory: " + dir.toAbsolutePath());
+
                         CopyOption[] opt = new CopyOption[]{COPY_ATTRIBUTES, REPLACE_EXISTING};
                         Path newDirectory = destinationVectorPath.resolve(sourceSvgPath.relativize(dir));
                         try {
@@ -74,7 +76,11 @@ public class SvgFilesProcessor {
 
                     public FileVisitResult visitFile(Path file,
                                                      BasicFileAttributes attrs) throws IOException {
-                        convertToVector(file, destinationVectorPath.resolve(sourceSvgPath.relativize(file)));
+                        try {
+                            convertToVector(file, destinationVectorPath.resolve(sourceSvgPath.relativize(file)));
+                        } catch(Exception exc) {
+                            System.out.println("Exception on convertToVector " + exc.toString());
+                        }
                         return CONTINUE;
                     }
 


### PR DESCRIPTION
- Updated com.android.tools (conversion of some SVG files failed with the current one)
- Catch any exceptions during the SVG conversion. (after an exception during the conversion the file/directory walker stopped)